### PR TITLE
Include ScatterMoe Kernels and Incorporate With Megablocks Distributed Primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,7 @@ In the data parallel dimension, seperate shards (stylised as white and grey in t
 
 The key assumption here is that within a single data example (or batch) **the tokens assigned to each expert is roughly the same**, so each device will run in parallel for approximately the same amount of time, then moving on to the next batch. 
 - The challenge is to then manage slight differences in token numbers without dropping them; this is addressed by the `DroplessMoE` in megablocks using sparse matmuls.
-- for [train_accelerate_fsdp2.py](./train_accelerate_fsdp2.py) there is a choice for running scattermoe in place of the megablock kernels when passing `use_scattermoe=True`. But for this please install:
-    ```
-    pip install git+https://github.com/shawntan/scattermoe.git
-    ```
+- for [train_accelerate_fsdp2.py](./train_accelerate_fsdp2.py) there is a choice for running scattermoe in place of the megablock kernels when passing `use_scattermoe=True`. 
 
 
 ### Performance
@@ -33,11 +30,16 @@ The key assumption here is that within a single data example (or batch) **the to
 Expert parallel will be able to achieve increased throughputs if the number of tokens to each expert are well-balanced.
 
 
-Emb, Attn | MoE | train_runtime (s) | train_steps_per_sec | gpu_mem_used_peak (MiB)
---|--|--|--|--
-FSDP2 | FSDP2 | 12345 | 0.033 | 54163
-FSDP2 | megablocks | 3478 | 0.117 | 46692
-
+Type | ep_size | Emb, Attn | MoE | train_runtime (s) | gpu_mem_used_peak (MiB) | gpu_mem_alloc (MiB)
+--|--|--|--|--|--|--
+Full | no parallel | FSDP2 | FSDP2 | 3037 | 59 | 47
+Full | 8 | FSDP2 | megablocks | 871 | 49 | 36
+Full | 4 | FSDP2 | megablocks | OOM  | OOM | OOM
+LoRA (16, attn) | no parallel | FSDP2 | FSDP2 | 2137 | 22 | 12
+LoRA (16, attn) | 8 | FSDP2 | megablocks | 878 | 14 | 12
+LoRA (16, attn) | 4 | FSDP2 | megablocks | 878 | 26 | 25
+LoRA (16, attn) | 4 | FSDP2 | **scatterblocks** | **831** | **25** | **24**
+LoRA (16, **all**) | 4 | FSDP2 | **scatterblocks** | 880 | 26 | 25
 
 
 ## Running
@@ -46,6 +48,8 @@ Install dependencies (will require CUDA_TOOLKIT to build megablocks):
 ```
 pip install -r requirements.txt
 ```
+
+### Full Finetuning
 
 Running FSDP1 script uses accelerate. The equivalent run to above would be 
 - [`accelerate.yaml`](./accelerate.yaml) are the launcher defaults.
@@ -87,6 +91,21 @@ torchrun --nproc_per_node=8 \
 	--debug True \
 	--learning_rate 5e-5
 ```
+
+
+ Use [scattermoe](https://github.com/shawntan/scattermoe) instead of megablocks kernels to handle the DroplessMoe.   
+For `scattermoe` (in full-finetuning):
+- set `use_scattermoe` to `True`.
+
+
+### LoRA Finetuning
+
+This can be done with the following additional flags:
+- `use_lora`: set as
+    * `none`: (default). No adapters.
+    * `all`: adapters on both attention and mlp.
+    * `attn-only`: adapters only on attention.
+ - `use_scattermoe`: For `all` and `mlp-only`, this must be set to `True`; only scattermoe kernels support LoRA (the megablocks kernels do not).
 
 ### Running Tests
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ In the data parallel dimension, seperate shards (stylised as white and grey in t
 
 The key assumption here is that within a single data example (or batch) **the tokens assigned to each expert is roughly the same**, so each device will run in parallel for approximately the same amount of time, then moving on to the next batch. 
 - The challenge is to then manage slight differences in token numbers without dropping them; this is addressed by the `DroplessMoE` in megablocks using sparse matmuls.
+- for [train_accelerate_fsdp2.py](./train_accelerate_fsdp2.py) there is a choice for running scattermoe in place of the megablock kernels when passing `use_scattermoe=True`. But for this please install:
+    ```
+    pip install git+https://github.com/shawntan/scattermoe.git
+    ```
+
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ torchrun --nproc_per_node=8 \
 	--learning_rate 5e-5
 ```
 
+### Running Tests
+
+Make sure to set the path:
+```
+PYTHONPATH=. pytest tests
+```
+
 
 ## Implementation Discussion
 

--- a/megablocks_utils/config_utils.py
+++ b/megablocks_utils/config_utils.py
@@ -54,6 +54,9 @@ def get_mlp_weights_lora(mod: torch.nn.Module, name: str = "w1"):
         A = B
         B = temp
 
+    A = resolve_dtensor(A)
+    B = resolve_dtensor(B)
+
     return (W, A, B, r, lora_alp)
 
 def update_mlp_registry():

--- a/megablocks_utils/config_utils.py
+++ b/megablocks_utils/config_utils.py
@@ -7,6 +7,7 @@ from megablocks.layers.dmlp_registry import _REGISTRY
 # from megablocks.layers import mlp
 from .sparse_mlp2 import SparseMLPv2
 from .peft_utils import ParallelDroplessMLP as LoRAParallelDroplessMLP
+import megablocks.ops as ops
 from megablocks.layers.moe import ParallelMLP
 from megablocks.layers.dmoe import ParallelDroplessMLP
 from megablocks.layers.mlp import resolve_dtensor
@@ -114,7 +115,7 @@ def update_mlp_registry():
         hidden_states = scattered_experts(
             x,
             *get_weights(self, "w1"),
-            1,
+            1 if self.args.moe_expert_model_parallelism else top_k,
             bin_ids, # sorted_expert_idxs,
             indices, # sorted_scattered_idxs,
             padded_block_idxs,
@@ -126,7 +127,7 @@ def update_mlp_registry():
         hidden_states2 = scattered_experts(
             x,
             *get_weights(self, "w3"),
-            1,
+            1 if self.args.moe_expert_model_parallelism else top_k,
             bin_ids, # sorted_expert_idxs,
             indices, # sorted_scattered_idxs,
             padded_block_idxs,
@@ -160,7 +161,6 @@ def update_mlp_registry():
         expert_capactiy,
         top_k,
     ):
-
         if self.args.mlp_impl == 'sparse':
             _func = self.sparse_permute_and_compute
         elif self.args.mlp_impl == 'scattermoe':
@@ -184,6 +184,39 @@ def update_mlp_registry():
     _REGISTRY['mlp']['scattermoe'] = SparseMLPv2
     
     ParallelDroplessMLP.permute_and_compute = permute_and_compute
+
+    # this is the permute and compute for the ParallelMLP version
+    # - we need to overide it with the above permute and compute
+    # - the "dmoe" version of parallel and compute has the 
+    #   binned gather and scatter done outside
+    # - this needs to reduce the expert weights
+    def permute_and_compute_parallel_mlp(
+        self,
+        x,
+        tokens_per_expert,  # unused
+        indices,
+        bin_ids,  # unused
+        expert_weights,
+        bins,
+        expert_capacity,
+        top_k,
+    ):
+        # need to handle the weights
+        # this is done in the MoE.permute_and_compute
+        if len(x.shape) == 3:
+            x = x.view(-1, x.shape[-1])
+
+        x = permute_and_compute(
+            self, x, tokens_per_expert, indices,
+            bin_ids, expert_weights, bins, expert_capacity, top_k
+        )
+        # following
+        # https://github.com/IBM/dolomite-engine/blob/b3ad5703ae32060f07339b664d3caca3e2c5e70a/dolomite_engine/hf_models/models/moe_dolomite/moe/base.py
+
+        return ops.scatter(x, indices, bin_ids, expert_weights, bins, top_k)
+
+    ParallelMLP.permute_and_compute = permute_and_compute_parallel_mlp
+    # ParallelMLP.permute_and_compute = permute_and_compute
 
     def forward_router(self, x):
         if self.training and self.args.moe_jitter_eps is not None:

--- a/megablocks_utils/peft_utils.py
+++ b/megablocks_utils/peft_utils.py
@@ -1,0 +1,88 @@
+
+import torch
+from peft.tuners.lora import LoraLayer
+# from megablocks.layers.moe import ParallelMLP
+# from megablocks.layers.dmoe import ParallelDroplessMLP
+# from megablocks.layers.arguments import Arguments
+from megablocks.layers import mpu
+from typing import Union, Any
+
+# this is the lora version
+# class ParallelDroplessMLP(ParallelMLP, LoraLayer):
+class ParallelDroplessMLP(torch.nn.Module, LoraLayer):
+
+    # Lora implemented in a dense layer
+    def __init__(
+        self,
+        base_layer,
+        adapter_name: str,
+        # mb_args: Arguments,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.0,
+        init_lora_weights: Union[bool, str] = True,
+        **kwargs,
+    ) -> None:
+        # super().__init__(mb_args)
+        super().__init__()
+        LoraLayer.__init__(self, base_layer, **kwargs)
+        # - base_layer will be ParallelMLP
+        #  
+        num_experts = mpu.experts_per_rank(self.args)
+
+        # we need to it cover the base layer
+        # - this will have A to be size (k, hd)
+        # - this will have B to be size (ffn, k)
+        self.in_features = base_layer.hidden_size * num_experts
+        self.out_features = base_layer.ffn_hidden_size * num_experts
+
+        # dummy not really used
+        self._active_adapter = adapter_name
+
+        base_layer._lora_pointers = {}
+
+        # assume that all the parameters of ParallelMLP.mlp 
+        # are weights
+        # - should be single layer
+        for name, _ in base_layer.mlp.named_parameters():
+            self.update_layer(
+                name,
+                r,
+                lora_alpha=lora_alpha,
+                lora_dropout=lora_dropout,
+                init_lora_weights=init_lora_weights,
+                use_rslora=False,
+                use_dora=False,
+            )
+
+            # need to adjust the A
+            # - ()
+            A = getattr(self.lora_A, name)
+            A.weight.data = A.weight.data.T # HACK
+
+            B = getattr(self.lora_B, name)
+
+            # we need to upcast the adapter weights because
+            # it is otherwise problematic for the kernel
+            # A.weight.data = A.weight.data.to(torch.float32)
+            # B.weight.data = B.weight.data.to(torch.float32)
+
+            r = self.r[name]
+            alpha = self.lora_alpha[name]
+            # put pointers in the base layer 
+            base_layer._lora_pointers[
+                name
+            ] = (
+                A.weight, B.weight, r, alpha,
+                base_layer.hidden_size, base_layer.ffn_hidden_size,
+            )
+    
+    def __getattr__(self, name: str) -> Any:
+        """Forward missing attributes to the wrapped module."""
+        try:
+            return super().__getattr__(name)  # defer to nn.Module's logic
+        except AttributeError:
+            return getattr(self.base_layer, name)
+
+    def forward(self, *args, **kwargs):
+        return self.base_layer(*args, **kwargs)

--- a/megablocks_utils/peft_utils.py
+++ b/megablocks_utils/peft_utils.py
@@ -62,11 +62,6 @@ class ParallelDroplessMLP(torch.nn.Module, LoraLayer):
 
             B = getattr(self.lora_B, name)
 
-            # we need to upcast the adapter weights because
-            # it is otherwise problematic for the kernel
-            # A.weight.data = A.weight.data.to(torch.float32)
-            # B.weight.data = B.weight.data.to(torch.float32)
-
             r = self.r[name]
             alpha = self.lora_alpha[name]
             # put pointers in the base layer 

--- a/megablocks_utils/peft_utils.py
+++ b/megablocks_utils/peft_utils.py
@@ -41,12 +41,15 @@ class ParallelDroplessMLP(torch.nn.Module, LoraLayer):
         self._active_adapter = adapter_name
 
         device_mesh = ARTIFACTS.get('device_mesh')
+        ep_degree = 1
         if device_mesh is not None:
             # for A and B, of size ff_dim x hidd
-            placements = (
-                [Shard(0)] + 
-                [Replicate() for _ in range(device_mesh.ndim-1)]
-            )
+            # placements = (
+            #     [Shard(0)] + 
+            #     [Replicate() for _ in range(device_mesh.ndim-1)]
+            # )
+            _, ep_degree = device_mesh.shape
+            placements = [Replicate(), Shard(0)]
 
         base_layer._lora_pointers = {}
 
@@ -89,7 +92,8 @@ class ParallelDroplessMLP(torch.nn.Module, LoraLayer):
                     A, 'weight', 
                     torch.nn.Parameter(
                         distribute_tensor(
-                            weight.repeat(num_experts, 1), 
+                            # weight.repeat(num_experts, 1), 
+                            weight.repeat(ep_degree, 1), 
                             device_mesh,
                             placements
                         ),
@@ -113,7 +117,8 @@ class ParallelDroplessMLP(torch.nn.Module, LoraLayer):
                     B, 'weight', 
                     torch.nn.Parameter(
                         distribute_tensor(
-                            weight.repeat(num_experts, 1), 
+                            # weight.repeat(num_experts, 1), 
+                            weight.repeat(ep_degree, 1), 
                             device_mesh,
                             placements
                         ),
@@ -130,6 +135,148 @@ class ParallelDroplessMLP(torch.nn.Module, LoraLayer):
             ] = (
                 A.weight, B.weight, r, alpha,
                 base_layer.hidden_size, base_layer.ffn_hidden_size,
+            )
+    
+    def __getattr__(self, name: str) -> Any:
+        """Forward missing attributes to the wrapped module."""
+        try:
+            return super().__getattr__(name)  # defer to nn.Module's logic
+        except AttributeError:
+            return getattr(self.base_layer, name)
+
+    def forward(self, *args, **kwargs):
+        return self.base_layer(*args, **kwargs)
+
+class ParallelMLP(torch.nn.Module, LoraLayer):
+
+    # Lora implemented in a dense layer
+    def __init__(
+        self,
+        base_layer,
+        adapter_name: str,
+        # mb_args: Arguments,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.0,
+        init_lora_weights: Union[bool, str] = True,
+        **kwargs,
+    ) -> None:
+        # super().__init__(mb_args)
+        super().__init__()
+        LoraLayer.__init__(self, base_layer, **kwargs)
+        # - base_layer will be ParallelMLP
+        #  
+        num_experts = mpu.experts_per_rank(self.args)
+
+        # dummy not really used
+        self._active_adapter = adapter_name
+
+        device_mesh = ARTIFACTS.get('device_mesh')
+        ep_degree = 1
+        if device_mesh is not None:
+            # for A and B, of size ff_dim x hidd
+            placements = {
+                "A": [Replicate(), Replicate()],
+                "B": [Replicate(), Shard(0)],
+            } 
+            _, ep_degree = device_mesh.shape
+            # placements = (
+            #     [Shard(0)] + 
+            #     [Replicate() for _ in range(device_mesh.ndim-1)]
+            # )
+            # placements = [Replicate(), Shard(0)]
+
+        # we need to it cover the base layer
+        # - this will have A to be size (k, hd)
+        # - this will have B to be size (ffn, k)
+        self.in_features = base_layer.hidden_size * num_experts
+        # self.out_features = base_layer.ffn_hidden_size * num_experts // ep_degree
+        self.out_features = base_layer.ffn_hidden_size * num_experts
+
+        base_layer._lora_pointers = {}
+
+        # assume that all the parameters of ParallelMLP.mlp 
+        # are weights
+        # - should be single layer
+        for name, _ in base_layer.mlp.named_parameters():
+            self.update_layer(
+                name,
+                r,
+                lora_alpha=lora_alpha,
+                lora_dropout=lora_dropout,
+                init_lora_weights=init_lora_weights,
+                use_rslora=False,
+                use_dora=False,
+            )
+
+            # need to adjust the A
+            # - ()
+            A = getattr(self.lora_A, name)
+            if device_mesh is None:
+                A.weight.data = A.weight.data.T # HACK
+            else:
+                weight = A.weight.data.T
+
+                # must cast here otherwise, the casting on the 
+                # Dtensor will not affect the local
+                if self.args.bf16 or self.args.fp16:
+                    weight = weight.to(
+                        torch.bfloat16 if self.args.bf16
+                        else torch.float16
+                    )
+
+                # - NOTE: if we do it this way, all reps
+                # will begin with the same initialization of A
+                # - it is ok for random, but not ok for other
+                # - types of intialization
+                delattr(A, 'weight')
+                setattr(
+                    A, 'weight', 
+                    torch.nn.Parameter(
+                        distribute_tensor(
+                            # weight.repeat(ep_degree, 1), 
+                            weight,
+                            device_mesh,
+                            placements["A"]
+                        ),
+                        requires_grad=True
+                    )
+                )
+
+            B = getattr(self.lora_B, name)
+            if device_mesh is not None:
+                weight = B.weight.data
+
+                # cast (see above)
+                if self.args.bf16 or self.args.fp16:
+                    weight = weight.to(
+                        torch.bfloat16 if self.args.bf16
+                        else torch.float16
+                    )
+
+                delattr(B, 'weight')
+                setattr(
+                    B, 'weight', 
+                    torch.nn.Parameter(
+                        distribute_tensor(
+                            weight.repeat(ep_degree, 1), 
+                            device_mesh,
+                            placements["B"]
+                        ),
+                        requires_grad=True
+                    )
+                )
+
+            r = self.r[name]
+            alpha = self.lora_alpha[name]
+
+            # put pointers in the base layer 
+            base_layer._lora_pointers[
+                name
+            ] = (
+                A.weight, B.weight, r, alpha,
+                # base_layer.hidden_size, base_layer.ffn_hidden_size // ep_degree,
+                base_layer.hidden_size, base_layer.ffn_hidden_size
             )
     
     def __getattr__(self, name: str) -> Any:

--- a/megablocks_utils/shard_moe_utils.py
+++ b/megablocks_utils/shard_moe_utils.py
@@ -28,6 +28,7 @@ def get_moe_kwargs(
     has_bias: bool = False, # if the MOE has bias
     fp16: bool = False,
     bf16: bool = False,
+    mlp_impl: str = 'sparse',
 ):
     return {
         "hidden_size": config.hidden_size,
@@ -40,6 +41,7 @@ def get_moe_kwargs(
         "moe_normalize_expert_weights": True,
         "fp16": fp16,
         "bf16": bf16,
+        "mlp_impl": mlp_impl,
     }
 
 # trick to get the resolved cache file to acccess the safetensor

--- a/megablocks_utils/tpmoe.py
+++ b/megablocks_utils/tpmoe.py
@@ -1,0 +1,32 @@
+from  megablocks.layers.moe import MoE, ParallelMLP
+from megablocks.layers import common, dmlp_registry, moe, mpu
+from megablocks.layers.arguments import Arguments
+
+class TpMLP(moe.ParallelMLP):
+    def __init__(self, args: Arguments):
+        super().__init__(args)
+        self.hidden_size = args.hidden_size
+        self.ffn_hidden_size = mpu.features_per_rank(args)
+
+        # REMOVE THIS?
+        assert args.mlp_impl == 'scattermoe', \
+            "only scattermoe version of TP available"
+
+    # this will implement a sharded TP MLP
+    def forward_once(self, x, expert_weights, top_experts):
+        pass
+
+
+# tensor parallel version
+class TpMoE(MoE):
+    
+    # - MoE._init_experts_mlp initializes experts to 
+    #  the correct type of MLP
+    # 
+    # MoE.router(x) is called and returns
+    # - scores, expert_weights, expert_indices
+    # - these are passed to MoE.experts
+    # ParallelMLP.forward will call ParallelMLP.forward_once
+
+    def _init_experts_mlp(self, args: Arguments):
+        return TpMLP(args)

--- a/requirements-scattermoe.txt
+++ b/requirements-scattermoe.txt
@@ -1,0 +1,1 @@
+pip install git+https://github.com/shawntan/scattermoe.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ tqdm
 fire
 
 peft
+
+pytest # for tests

--- a/scattermoe_utils/kernels/ops.py
+++ b/scattermoe_utils/kernels/ops.py
@@ -1,0 +1,303 @@
+import torch
+import triton
+import triton.language as tl
+from torch.nn import functional as F
+
+BLOCK_M = 128
+
+def _scatter2scatter_configs():
+    return [
+        triton.Config({'BLOCK_N': 128, 'BLOCK_K': 32}, num_stages=4, num_warps=4),
+    ]
+
+@triton.autotune(configs=_scatter2scatter_configs(), key=['M', 'N', 'K'], )
+@triton.heuristics({
+    "NO_K_MASK": lambda args: (args['K'] % args['BLOCK_K']) == 0,
+    "NO_N_MASK": lambda args: (args['N'] % args['BLOCK_N']) == 0,
+})
+@triton.jit
+def _scatter2scatter_lora(
+    X_ptr, stride_xm, stride_xk,
+    W_ptr, stride_we, stride_wk, stride_wn,
+    A_ptr, stride_ae, stride_ak, 
+    B_ptr, stride_be, stride_bn, 
+    Y_ptr, stride_ym, stride_yn,
+    grouped_idx_ptr, expert_idxs_ptr, block_start_idx_ptr,
+    FAN_OUT: tl.constexpr,
+    M, K: tl.constexpr, N: tl.constexpr, E: tl.constexpr,
+    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+    ACC_TYPE: tl.constexpr,
+    OUT_M,
+    scaling,
+    allow_tf32: tl.constexpr,
+    x_grouped: tl.constexpr, y_grouped: tl.constexpr,
+    NO_K_MASK: tl.constexpr, NO_N_MASK: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+
+    N_BLOCK_COUNT = tl.cdiv(N, BLOCK_N)
+    M_block_id = pid // N_BLOCK_COUNT
+    N_block_id = pid % N_BLOCK_COUNT
+    M_range = tl.arange(0, BLOCK_M)
+    block_start_idx = tl.load(block_start_idx_ptr + M_block_id)
+    # M_block = tl.max_contiguous((block_start_idx + M_range) % OUT_M, BLOCK_M)
+    M_block = tl.max_contiguous(block_start_idx + M_range, BLOCK_M)
+    E_idxs = tl.load(expert_idxs_ptr + M_block, mask=M_block < (FAN_OUT * M), other=E)
+    E_idx = tl.min(E_idxs)
+    E_mask = E_idxs == E_idx
+    M_idx = tl.load(grouped_idx_ptr + M_block, mask=E_mask, other=0)
+    if x_grouped:
+        M_in_idx = M_block
+    else:
+        M_in_idx = M_idx // FAN_OUT
+
+    if y_grouped:
+        M_out_idx = M_block
+    else:
+        M_out_idx = M_idx
+
+    K_block = tl.arange(0, BLOCK_K)
+
+    N_block = N_block_id * BLOCK_N  + tl.arange(0, BLOCK_N)
+    N_mask = N_block < N
+    # N_block = tl.max_contiguous(tl.multiple_of(N_block % N, BLOCK_N), BLOCK_N)
+    # N_block = N_block_id * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    X_blk_ptrs = X_ptr + M_in_idx[:, None] * stride_xm + K_block[None, :] * stride_xk
+    W_blk_ptrs = W_ptr + K_block[:, None] * stride_wk + N_block[None, :] * stride_wn + E_idx * stride_we
+    A_blk_ptrs = A_ptr + K_block[:, None] * stride_ak + E_idx * stride_ae
+    B_blk_ptrs = B_ptr + N_block[None, :] * stride_bn + E_idx * stride_be
+
+    # b can be loaded outside because it has no dependence on K
+    b = tl.load(B_blk_ptrs, mask=N_mask[None, :])
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
+    iters = tl.cdiv(K, BLOCK_K)
+    for K_block_id in range(0, iters):
+        if NO_K_MASK:
+            x = tl.load(X_blk_ptrs, mask=E_mask[:, None])
+            if NO_N_MASK or K_block_id < (iters - 1):
+                w = tl.load(W_blk_ptrs)
+            else:
+                w = tl.load(W_blk_ptrs, mask=N_mask[None, :])
+        else:
+            K_mask = (K_block_id * BLOCK_K + K_block) < K
+            x = tl.load(X_blk_ptrs, mask=E_mask[:, None] & K_mask[None, :])
+            w = tl.load(W_blk_ptrs, mask=K_mask[:, None] & N_mask[None, :])
+            a = tl.load(A_blk_ptrs, mask=K_mask[:, None])
+
+        # accumulate
+        # - acummulate the base layer
+        acc += tl.dot(x, w, allow_tf32=allow_tf32, out_dtype=ACC_TYPE)
+
+        # - accumulate the adapter
+        interim = tl.dot(x, a, allow_tf32=allow_tf32, out_dtype=ACC_TYPE)
+        interim *= scaling
+        acc += tl.dot(interim, b, allow_tf32=allow_tf32, out_dtype=ACC_TYPE)
+
+        # move pointers in K
+        # NOTE: b has no dependence on K, so it doesnt need to move
+        X_blk_ptrs += BLOCK_K * stride_xk
+        W_blk_ptrs += BLOCK_K * stride_wk
+        A_blk_ptrs += BLOCK_K * stride_ak
+
+    Y_blk_ptrs = Y_ptr + (M_out_idx[:, None] * stride_ym + N_block[None, :] * stride_yn)
+    tl.store(Y_blk_ptrs, acc, mask=E_mask[:, None] & N_mask[None, :])
+
+def scatter2scatter_lora(
+    X, W, A, B, scaling,
+    sorted_expert_idxs, sorted_scattered_idxs, k,
+    padded_block_idxs, x_grouped=False, y_grouped=False,
+    out=None
+):
+    assert sorted_scattered_idxs.size(0) == sorted_expert_idxs.size(0)
+    assert sorted_scattered_idxs.size(0) == X.size(0) * k
+
+    ## TODO: do size checks on A, B
+
+    # Pre-kernel setup
+    x_dim = X.size(-1)
+    y_dim = W.size(-1)
+    L_scattered = sorted_expert_idxs.size(0)
+    if out is None:
+        O = torch.empty((L_scattered, y_dim), device=X.device, dtype=X.dtype)
+    else:
+        assert out.size(0) == L_scattered and out.size(1) == y_dim
+        O = out
+
+    def grid(META):
+        grid_num = (
+            padded_block_idxs.size(0) *
+            triton.cdiv(META['N'], META['BLOCK_N']),
+        )
+        return grid_num
+    with torch.cuda.device(X.device):
+        _scatter2scatter_lora[grid](
+            # X_ptr, stride_xm, stride_xk,
+            X, X.stride(0), X.stride(1),
+            # W_ptr, stride_we, stride_wk, stride_wn,
+            W, W.stride(0), W.stride(1), W.stride(2),
+            # A_ptr, stride_ae, stride_ak, 
+            A, A.stride(0), A.stride(1), 
+            # B_ptr, stride_be, stride_bn, 
+            B, B.stride(0), B.stride(1), 
+            # Y_ptr, stride_ym, stride_yn,
+            O, O.stride(0), O.stride(1),
+            grouped_idx_ptr=sorted_scattered_idxs,
+            expert_idxs_ptr=sorted_expert_idxs,
+            block_start_idx_ptr=padded_block_idxs,
+            FAN_OUT=k,
+            M=X.size(0),
+            K=X.size(1),
+            N=O.size(1), E=W.size(0),
+            BLOCK_M=BLOCK_M,
+            ACC_TYPE=tl.float32,
+            OUT_M=O.size(0),
+            alpha=scaling,
+            allow_tf32=True,
+            x_grouped=x_grouped, y_grouped=y_grouped,
+        )
+        return O
+
+
+def _config_XtY():
+    return [
+        triton.Config({'BLOCK_N': 128, 'BLOCK_K': 128, 'BLOCK_M': 32}, num_stages=4, num_warps=4),
+    ]
+
+def group_bwd_AB(DY, X, A, B, expert_offsets, E, lora_alp, lora_r):
+    DA = torch.zeros((E, X.size(-1), lora_r), device=DY.device, dtype=DY.dtype)
+    DB = torch.zeros((E, lora_r, DY.size(-1)), device=DY.device, dtype=DY.dtype)
+    def grid(META):
+        grid = (
+            E * triton.cdiv(META['K'], META['BLOCK_K']),
+            triton.cdiv(META['N'], META['BLOCK_N']),
+        )
+        return grid
+    
+    with torch.cuda.device(DY.device):
+        _groupXtY_lora[grid](
+            # DY_ptr, stride_dym, stride_dyk,
+            DY, DY.stride(0), DY.stride(1),
+            # X_ptr, stride_xm, stride_xn,
+            X, X.stride(0), X.stride(1),
+            # DA_ptr, stride_dae, stride_dak,
+            DA, DA.stride(0), DA.stride(1),
+            # DB_ptr, stride_dbe, stride_dbn,
+            DB, DB.stride(0), DB.stride(1), 
+            # A_ptr, stride_ae, stride_ak, 
+            A.permute(0,2,1), A.stride(0), A.stride(2), 
+            # B_ptr, stride_be, stride_bn, 
+            B.permute(0,2,1), B.stride(0), B.stride(2), 
+            # expert_offsets_ptr,
+            expert_offsets,
+            # K: tl.constexpr, N: tl.constexpr,
+            M=DY.size(0), N=DY.size(-1), K=X.size(-1),
+            lora_r=lora_r, lora_alp=lora_alp,
+            # ACC_TYPE: tl.constexpr,
+            ACC_TYPE=tl.float32,
+            allow_tf32=True
+        )
+        return DA.permute(0, 2, 1), DB.permute(0,2,1)
+
+@triton.autotune(configs=_config_XtY(), key=['M', 'N', 'K'], )
+@triton.heuristics({
+    "NO_K_MASK": lambda args: (args['K'] % args['BLOCK_K']) == 0,
+    "NO_N_MASK": lambda args: (args['N'] % args['BLOCK_N']) == 0,
+})
+@triton.jit
+def _groupXtY_lora(
+    DY_ptr, stride_dym, stride_dyk,
+    X_ptr, stride_xm, stride_xn,
+    DA_ptr, stride_dae, stride_dak, 
+    DB_ptr, stride_dbe, stride_dbn,
+    At_ptr, stride_ae, stride_ak,  # transposed
+    Bt_ptr, stride_be, stride_bn,  # transposed
+    expert_offsets_ptr,
+    M, K: tl.constexpr, N: tl.constexpr,
+    lora_r, lora_alp,
+    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
+    ACC_TYPE: tl.constexpr,
+    allow_tf32: tl.constexpr,
+    NO_K_MASK: tl.constexpr, NO_N_MASK: tl.constexpr
+):
+    pid0 = tl.program_id(axis=0)
+    pid1 = tl.program_id(axis=1)
+    num0 = tl.num_programs(0)
+    num1 = tl.num_programs(1)
+    pid1, pid0 = tl.swizzle2d(pid1, pid0, num1, num0, 128)
+
+    K_BLOCK_COUNT = tl.cdiv(K, BLOCK_K)
+    E_idx = pid0 // K_BLOCK_COUNT
+    K_block_id = pid0 % K_BLOCK_COUNT
+    N_block_id = pid1
+
+    if E_idx == 0:
+        start_idx = 0
+    else:
+        start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
+    end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int32)
+
+    K_block = K_block_id * BLOCK_K + tl.arange(0, BLOCK_K)
+    K_mask = K_block < K
+    K_block = tl.max_contiguous(tl.multiple_of(K_block % K, BLOCK_K), BLOCK_K)
+
+    N_block = N_block_id * BLOCK_N + tl.arange(0, BLOCK_N)
+    N_mask = N_block < N
+    N_block = tl.max_contiguous(tl.multiple_of(N_block % N, BLOCK_N), BLOCK_N)
+
+    # the K and B_blocks are transposed
+    At_blk_ptrs = At_ptr + K_block[None, :] * stride_ak + E_idx * stride_ae
+    Bt_blk_ptrs = Bt_ptr + N_block[:, None] * stride_bn + E_idx * stride_be
+
+    if NO_K_MASK:
+        a = tl.load(At_blk_ptrs)
+        bt = tl.load(Bt_blk_ptrs)
+    else:
+        # the masks are transposed
+        a = tl.load(At_blk_ptrs, mask=K_mask[None, :])
+        bt = tl.load(Bt_blk_ptrs, mask=N_mask[:, None])
+
+    scaling = lora_alp / lora_r
+    if end_idx > start_idx:
+        M_block = tl.max_contiguous(start_idx + tl.arange(0, BLOCK_M), BLOCK_M)
+
+        M_idxs = M_block
+        xt_blk_ptrs = X_ptr + K_block[:, None] * stride_xn + M_idxs[None, :] * stride_xm
+        dy_blk_ptrs = DY_ptr + M_idxs[:, None] * stride_dym + N_block[None, :] * stride_dyk
+
+        acc_A = tl.zeros((BLOCK_K, lora_r), dtype=ACC_TYPE)
+        acc_B = tl.zeros((lora_r, BLOCK_N), dtype=ACC_TYPE)
+        iters = tl.cdiv(end_idx - start_idx, BLOCK_M)
+        for i in range(0, iters):
+            M_mask = (i * BLOCK_M + M_block) < end_idx
+            if NO_K_MASK:
+                xt = tl.load(xt_blk_ptrs, mask=M_mask[None, :])
+            else:
+                xt = tl.load(xt_blk_ptrs, mask=K_mask[:, None] & M_mask[None, :])
+            if NO_N_MASK:
+                dy = tl.load(dy_blk_ptrs, mask=M_mask[:, None])
+            else:
+                dy = tl.load(dy_blk_ptrs, mask=M_mask[:, None] & N_mask[None, :])
+            # acc += tl.dot(xt, dy, out_dtype=ACC_TYPE, allow_tf32=allow_tf32)
+            xt_blk_ptrs += BLOCK_M * stride_xm
+            dy_blk_ptrs += BLOCK_M * stride_dym
+
+            interm = tl.dot(dy, bt, out_dtype=ACC_TYPE, allow_tf32=allow_tf32)
+            interm *= scaling
+            acc_A += tl.dot(xt, interm, out_dtype=ACC_TYPE, allow_tf32=allow_tf32)
+
+            interm = tl.dot(at, x, out_dtype=ACC_TYPE, allow_tf32=allow_tf32)
+            interm *= scaling
+            acc_B += tl.dot(interm, dy, out_dtype=ACC_TYPE, allow_tf32=allow_tf32)
+
+
+        # this one is not transposed
+        DA_blk_ptrs = DA_ptr + E_idx * stride_dae + K_block[:, None] * stride_dak 
+        acc_A = acc_A.to(DA_blk_ptrs.dtype.element_ty)
+        tl.store(DA_blk_ptrs, acc_A, mask=K_mask[:, None])
+
+        DB_blk_ptrs = DB_ptr + E_idx * stride_dbe + N_block[None, :] * stride_dbn
+        acc_B = acc_B.to(DB_blk_ptrs.dtype.element_ty)
+        tl.store(DB_blk_ptrs, acc_B, mask=N_mask[None, :])
+

--- a/scattermoe_utils/kernels/ops.py
+++ b/scattermoe_utils/kernels/ops.py
@@ -216,7 +216,7 @@ def group_bwd_AB(DY, X, A, B, scaling, expert_offsets, E):
     assert A.size(2) == B.size(1), "A and B have inconsistent inner dims."
 
     DA = torch.zeros((E, X.size(-1), A.size(2)), device=DY.device, dtype=DY.dtype)
-    DB = torch.zeros((E, A.size(2), DY.size(-1)), device=DY.device, dtype=DY.dtype)
+    DB = torch.zeros((E, B.size(1), DY.size(-1)), device=DY.device, dtype=DY.dtype)
     def grid(META):
         grid = (
             E * triton.cdiv(META['K'], META['BLOCK_K']),
@@ -229,17 +229,17 @@ def group_bwd_AB(DY, X, A, B, scaling, expert_offsets, E):
     
     with torch.cuda.device(DY.device):
         _groupXtY_lora[grid](
-            # DY_ptr, stride_dym, stride_dyk,
+            # DY_ptr, stride_dym, stride_dyn,
             DY, DY.stride(0), DY.stride(1),
-            # X_ptr, stride_xm, stride_xn,
+            # X_ptr, stride_xm, stride_xk,
             X, X.stride(0), X.stride(1),
-            # DA_ptr, stride_dae, stride_dan, stride_dar
+            # DA_ptr, stride_dae, stride_dak, stride_dar
             DA, DA.stride(0), DA.stride(1), DA.stride(2),
             # DB_ptr, stride_dbe, stride_dbr, stride_dbn,
             DB, DB.stride(0), DB.stride(1), DB.stride(2),
-            # At_ptr, stride_ae, stride_ar, stride_an,
+            # At_ptr, stride_ae, stride_ar, stride_ak,
             At, At.stride(0), At.stride(1), At.stride(2),
-            # Bt_ptr, stride_be, stride_bk, stride_br,
+            # Bt_ptr, stride_be, stride_bn, stride_br,
             Bt, Bt.stride(0), Bt.stride(1), Bt.stride(2),
             # expert_offsets_ptr,
             expert_offsets,
@@ -249,7 +249,7 @@ def group_bwd_AB(DY, X, A, B, scaling, expert_offsets, E):
             ACC_TYPE=tl.float32,
             allow_tf32=True
         )
-        return DA.permute(0, 2, 1), DB.permute(0,2,1)
+        return DA, DB
 
 @triton.autotune(configs=_config_XtY(), key=['M', 'N', 'K'], )
 @triton.heuristics({
@@ -258,12 +258,12 @@ def group_bwd_AB(DY, X, A, B, scaling, expert_offsets, E):
 })
 @triton.jit
 def _groupXtY_lora(
-    DY_ptr, stride_dym, stride_dyk,
-    X_ptr, stride_xm, stride_xn,
-    DA_ptr, stride_dae, stride_dan, stride_dar,
-    DB_ptr, stride_dbe, stride_dbr, stride_dbk,
-    At_ptr, stride_ae, stride_ar, stride_an,  # transposed
-    Bt_ptr, stride_be, stride_bk, stride_br,  # transposed
+    DY_ptr, stride_dym, stride_dyn,
+    X_ptr, stride_xm, stride_xk,
+    DA_ptr, stride_dae, stride_dak, stride_dar,
+    DB_ptr, stride_dbe, stride_dbr, stride_dbn,
+    At_ptr, stride_ae, stride_ar, stride_ak,  # transposed
+    Bt_ptr, stride_be, stride_bn, stride_br,  # transposed
     expert_offsets_ptr,
     M, K: tl.constexpr, N: tl.constexpr, R: tl.constexpr,
     scaling,
@@ -278,17 +278,17 @@ def _groupXtY_lora(
     # Y = X * (W + A*B*scaling)
     #   = X * W + X * A * B * scaling
 
-    # Consider a function f over domain R^K, i.e., f(Y)
+    # Consider a function f over domain R^n, i.e., f(Y)
     # - Let DY the be gradients flowing backwards, i.e., DY = df/dY
-    # - Let DY be of dimensions M, K, where K is from the domain of f and M is 
-    #   sequence.
+    # - Let DY be of dimensions M, N, where N is from the domain of f and M is 
+    #   sequence dimension.
     # - then the gradients DA for adapter A will be DA = X^t * DY * B^T * scaling
     #   and the gradients DB for adapter B will be DB = A^t * X^t * DY * scaling
 
     # The 2D grid is assumed to be:
     # (num_experts * K_BLOCK_COUNT, N_BLOCK_COUNT)
-    # - the input dimension is N
-    # - the output dimension is K
+    # - the input dimension is K
+    # - the output dimension is N
     # - X and DY are assumed to be grouped.
     # - expert_offsets_ptr are the offsets for accessing the expert groups.
 
@@ -315,80 +315,89 @@ def _groupXtY_lora(
         start_idx = tl.load(expert_offsets_ptr + E_idx - 1).to(tl.int32)
     end_idx = tl.load(expert_offsets_ptr + E_idx).to(tl.int32)
 
-    # - get the N_block for the input dimension
-    N_block = N_block_id * BLOCK_N + tl.arange(0, BLOCK_N)
-    N_mask = N_block < N
-    N_block = tl.max_contiguous(tl.multiple_of(N_block % N, BLOCK_N), BLOCK_N)
-
-    # - get the K_block for the output dimension
+    # - get the K_block for the input dimension
     K_block = K_block_id * BLOCK_K + tl.arange(0, BLOCK_K)
     K_mask = K_block < K
     K_block = tl.max_contiguous(tl.multiple_of(K_block % K, BLOCK_K), BLOCK_K)
 
+    # - get the N_block for the output dimension
+    N_block = N_block_id * BLOCK_N + tl.arange(0, BLOCK_N)
+    N_mask = N_block < N
+    N_block = tl.max_contiguous(tl.multiple_of(N_block % N, BLOCK_N), BLOCK_N)
+
     # - R range for lora dimension
     R_range = tl.arange(0, R)
 
-    # - M block for indices dimension
+    # - M block for indices (sequence) dimension
     M_block = tl.max_contiguous(start_idx + tl.arange(0, BLOCK_M), BLOCK_M)
 
-    # At: dimensions E, lora_r, N (transposed)
-    # Bt: dimensions E, K, lora_r (transposed)
-    At_blk_ptrs = At_ptr + E_idx * stride_ae + N_block[None, :] * stride_an + R_range[:, None] * stride_ar
-    Bt_blk_ptrs = Bt_ptr + E_idx * stride_be + K_block[:, None] * stride_bk + R_range[None, :] * stride_br
+    # At: dimensions E, lora_r, K (transposed)
+    # Bt: dimensions E, N, lora_r (transposed)
+    At_blk_ptrs = At_ptr + E_idx * stride_ae + K_block[None, :] * stride_ak + R_range[:, None] * stride_ar
+    Bt_blk_ptrs = Bt_ptr + E_idx * stride_be + N_block[:, None] * stride_bn + R_range[None, :] * stride_br
 
-    # - get the at and bt (transposed) weights
-    # - do not depend on indices dimension so can be loaded outside of loop
-    if NO_N_MASK:
-        at = tl.load(At_blk_ptrs)
-    else:
-        at = tl.load(At_blk_ptrs, mask=N_mask[None, :])
-
-    if NO_K_MASK:
-        bt = tl.load(Bt_blk_ptrs)
-    else:
-        bt = tl.load(Bt_blk_ptrs, mask=K_mask[:, None])
-
-    # - iterate over the (grouped) expert indices
+    # - iterate over the (grouped) expert indices (sequence)
+    # - check if end_idx and start_idx are valid
     if end_idx > start_idx:
 
-        M_idxs = M_block
-        xt_blk_ptrs = X_ptr +  M_idxs[None, :] * stride_xm + K_block[:, None] * stride_xn
-        dy_blk_ptrs = DY_ptr + M_idxs[:, None] * stride_dym + N_block[None, :] * stride_dyk
+        # - get the at and bt (transposed) weights
+        # - do not depend on indices dimension so can be loaded outside of loop
+        if NO_K_MASK:
+            at = tl.load(At_blk_ptrs)
+        else:
+            at = tl.load(At_blk_ptrs, mask=K_mask[None, :])
 
-        acc_A = tl.zeros((BLOCK_K, lora_r), dtype=ACC_TYPE)
-        acc_B = tl.zeros((lora_r, BLOCK_N), dtype=ACC_TYPE)
+        if NO_N_MASK:
+            bt = tl.load(Bt_blk_ptrs)
+        else:
+            bt = tl.load(Bt_blk_ptrs, mask=N_mask[:, None])
+
+        # - prepare for iteration
+        # - xt (transposed) created from (un-transposed) X_ptr
+        xt_blk_ptrs = X_ptr + M_block[None, :] * stride_xm + K_block[:, None] * stride_xk
+        dy_blk_ptrs = DY_ptr + M_block[:, None] * stride_dym + N_block[None, :] * stride_dyn
+
+        # - for accumulation
+        acc_A = tl.zeros((BLOCK_K, R), dtype=ACC_TYPE)
+        acc_B = tl.zeros((R, BLOCK_N), dtype=ACC_TYPE)
         iters = tl.cdiv(end_idx - start_idx, BLOCK_M)
+
+        # - iterate
         for i in range(0, iters):
 
-            # - get the M mask 
+            # - get the (sequence) M mask 
             M_mask = (i * BLOCK_M + M_block) < end_idx
+
+            # - load xt and dy
             if NO_K_MASK:
                 xt = tl.load(xt_blk_ptrs, mask=M_mask[None, :])
             else:
-                xt = tl.load(xt_blk_ptrs, mask=K_mask[:, None] & M_mask[None, :])
+                xt = tl.load(xt_blk_ptrs, mask=M_mask[None, :] & K_mask[:, None])
             if NO_N_MASK:
                 dy = tl.load(dy_blk_ptrs, mask=M_mask[:, None])
             else:
                 dy = tl.load(dy_blk_ptrs, mask=M_mask[:, None] & N_mask[None, :])
-            # acc += tl.dot(xt, dy, out_dtype=ACC_TYPE, allow_tf32=allow_tf32)
-            xt_blk_ptrs += BLOCK_M * stride_xm
-            dy_blk_ptrs += BLOCK_M * stride_dym
 
+            # compute DA = X^t * DY * B^T * scaling
             interm = tl.dot(dy, bt, out_dtype=ACC_TYPE, allow_tf32=allow_tf32)
             interm *= scaling
             acc_A += tl.dot(xt, interm, out_dtype=ACC_TYPE, allow_tf32=allow_tf32)
 
-            interm = tl.dot(at, x, out_dtype=ACC_TYPE, allow_tf32=allow_tf32)
+            # compute DB = A^t * X^t * DY * scaling
+            interm = tl.dot(at, xt, out_dtype=ACC_TYPE, allow_tf32=allow_tf32)
             interm *= scaling
             acc_B += tl.dot(interm, dy, out_dtype=ACC_TYPE, allow_tf32=allow_tf32)
 
+            # - move pointers
+            xt_blk_ptrs += BLOCK_M * stride_xm
+            dy_blk_ptrs += BLOCK_M * stride_dym
 
-        # this one is not transposed
-        DA_blk_ptrs = DA_ptr + E_idx * stride_dae + K_block[:, None] * stride_dan 
+        # - store output for DA and DB
+        DA_blk_ptrs = DA_ptr + E_idx * stride_dae + K_block[:, None] * stride_dak + R_range[None, :] * stride_dar
         acc_A = acc_A.to(DA_blk_ptrs.dtype.element_ty)
         tl.store(DA_blk_ptrs, acc_A, mask=K_mask[:, None])
 
-        DB_blk_ptrs = DB_ptr + E_idx * stride_dbe + N_block[None, :] * stride_dbk
+        DB_blk_ptrs = DB_ptr + E_idx * stride_dbe + N_block[None, :] * stride_dbn + R_range[:, None] * stride_dbr
         acc_B = acc_B.to(DB_blk_ptrs.dtype.element_ty)
         tl.store(DB_blk_ptrs, acc_B, mask=N_mask[None, :])
 

--- a/scattermoe_utils/kernels/ops.py
+++ b/scattermoe_utils/kernels/ops.py
@@ -136,7 +136,6 @@ def _scatter2scatter_lora(
         # - accumulate adapter
         # - interim = X * A * scaling
         # - interm wil be of dimensions M_block by lora_r
-        # interim = tl.dot(x, a, allow_tf32=allow_tf32, out_dtype=ACC_TYPE)
         interim = tl.dot(x, a)
         interim *= scaling
         acc += tl.dot(interim.to(b.dtype), b, allow_tf32=allow_tf32, out_dtype=ACC_TYPE)

--- a/scattermoe_utils/parallel_linear_lora.py
+++ b/scattermoe_utils/parallel_linear_lora.py
@@ -1,7 +1,11 @@
 import torch
 import torch.nn as nn
 from .kernels import ops
-import scattermoe.kernels as orig_kernels
+
+try:
+    import scattermoe.kernels as orig_kernels
+except ImportError:
+    pass
 
 # lora_scaling is lora_alpha / lora_r
 class ParallelLinearLora(torch.autograd.Function):

--- a/scattermoe_utils/parallel_linear_lora.py
+++ b/scattermoe_utils/parallel_linear_lora.py
@@ -154,8 +154,28 @@ def parallel_linear_lora(
     lora_r, lora_alp, k,
     sorted_expert_idxs, sorted_scattered_idxs,
     padded_block_idxs, expert_offsets,
-    gates=None, grouped_in=False, grouped_out=False
+    gates=None, grouped_in=False, grouped_out=False,
+    use_khd=True,
 ):
+
+    if use_khd:
+        from khd.kernels.scattermoe.triton_implementation.ops import _ScatteredExperts
+        return _ScatteredExperts.apply(
+            inputs,
+            expert_weights,
+            k,
+            sorted_expert_idxs,
+            sorted_scattered_idxs,
+            padded_block_idxs,
+            expert_offsets,
+            gates,
+            grouped_in,
+            grouped_out,
+            expert_lora_A,
+            expert_lora_B,
+            lora_alp
+        )
+
     results = ParallelLinearLora.apply(
         inputs, expert_weights, 
         expert_lora_A, expert_lora_B, 

--- a/scattermoe_utils/parallel_linear_lora.py
+++ b/scattermoe_utils/parallel_linear_lora.py
@@ -1,0 +1,139 @@
+import torch
+import torch.nn as nn
+from .kernels import ops
+import scattermoe.kernels as orig_kernels
+
+# lora_scaling is lora_alpha / lora_r
+class ParallelLinearLora(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx, x, expert_weights, 
+        expert_lora_A, expert_lora_B, 
+        lora_r, lora_alp, k,
+        sorted_expert_idxs, sorted_scattered_idxs,
+        padded_block_idxs, expert_offsets,
+        gates=None, grouped_in=False, grouped_out=False,
+    ):
+
+        output = ops.scatter2scatter_lora(
+            X=x, W=expert_weights, A=expert_lora_A, B=expert_lora_B,
+            scaling=(lora_alp / lora_r),
+            sorted_expert_idxs=sorted_expert_idxs,
+            sorted_scattered_idxs=sorted_scattered_idxs,
+            padded_block_idxs=padded_block_idxs,
+            k=k, x_grouped=grouped_in, y_grouped=grouped_out
+        )
+        if gates is not None:
+            output_expanded = output.view(gates.size(0), gates.size(1), output.size(-1))
+            output = torch.bmm(
+                gates[:, None, :],
+                output_expanded
+            ).squeeze(1)
+        else:
+            output_expanded = None
+
+        ctx.save_for_backward(
+            x, expert_weights,
+            expert_lora_A, expert_lora_B,
+            sorted_expert_idxs,
+            sorted_scattered_idxs,
+            padded_block_idxs, expert_offsets,
+            gates,
+            output_expanded
+        )
+        ctx.grouped_in = grouped_in
+        ctx.grouped_out = grouped_out
+        ctx.k = k
+        ctx.lora_r = lora_r
+        ctx.lora_alp = lora_alp
+        return output
+    @staticmethod
+    def backward(ctx, grad_out):
+        (x, expert_weights,
+         expert_lora_A, expert_lora_B, 
+         sorted_expert_idxs,
+         sorted_scattered_idxs,
+         padded_block_idxs, expert_offsets,
+         gates, output_expanded) = ctx.saved_tensors
+        k = ctx.k
+        lora_r = ctx.lora_r
+        lora_alp = ctx.lora_alp
+        grouped_in = ctx.grouped_in
+        grouped_out = ctx.grouped_out
+        if gates is not None:
+            # calculate gates gradient
+            d_gates = torch.bmm(output_expanded, grad_out[:, :, None]).squeeze(-1)
+            gates_flat = gates.flatten()
+            gate_fan = gates.size(1)
+            grouped_grad_out = output_expanded.flatten(0, 1) # reuse expanded buffer later
+        else:
+            d_gates = None
+            gates_flat = None
+            gate_fan = 1
+            grouped_grad_out = None
+
+        if grouped_out:
+            grouped_grad_out = grad_out
+        else:
+            grouped_grad_out = orig_kernels.ops.group(grad_out, sorted_scattered_idxs,
+                                                 fan_out=gate_fan, coeff=gates_flat,
+                                                 out=grouped_grad_out)
+        if grouped_in:
+            grouped_x = x
+            d_expanded_input = None
+        else:
+            grouped_x = orig_kernels.ops.group(x, sorted_scattered_idxs, fan_out=k)
+            d_expanded_input = grouped_x
+        d_weights_A, d_weights_B = ops.group_bwd_AB(
+            DY=grouped_grad_out, X=grouped_x,
+            A=expert_lora_A, B=expert_lora_B,
+            expert_offsets=expert_offsets,
+            E=expert_weights.size(0),
+            lora_alp=lora_alp,
+            lora_r=lora_r,
+        )
+
+        # NOTE: this maybe can be fused
+        d_expanded_input = ops.scatter2scatter_lora(
+            X=grouped_grad_out, x_grouped=True,
+            W=expert_weights.permute(0, 2, 1),
+            A=expert_lora_B.permute(0,1,2),
+            B=expert_lora_A.permute(0,1,2),
+            scaling=(lora_alp/lora_r),
+            padded_block_idxs=padded_block_idxs,
+            sorted_expert_idxs=sorted_expert_idxs,
+            sorted_scattered_idxs=sorted_scattered_idxs,
+            k=1,
+            y_grouped=grouped_in,
+            out=d_expanded_input # Reuse grouped_x buffer
+        )
+
+        if k == 1:
+            d_input = d_expanded_input
+        else:
+            d_input = d_expanded_input.view(x.size(0), k, d_expanded_input.size(-1)).sum(-2)
+        # print("backward end.")
+        return (
+            # x, expert_weights,
+            d_input, None, 
+            # expert_lora_A, expert_lora_B, expert_lora_scaling,
+            d_weights_A, d_weights_B, None,
+            # expert_lora_scaling, k
+            None, None,
+            # sorted_expert_idxs, sorted_scattered_idxs,
+            None, None,
+            # padded_block_idxs, expert_offsets,
+            None, None,
+            # gates
+            d_gates, None, None
+        )
+
+def parallel_linear(inputs, expert_weights, k,
+                    sorted_expert_idxs, sorted_scattered_idxs,
+                    padded_block_idxs, expert_offsets,
+                    gates=None, grouped_in=False, grouped_out=False):
+    results = ParallelLinearLora.apply(inputs, expert_weights, k,
+                                   sorted_expert_idxs, sorted_scattered_idxs,
+                                   padded_block_idxs, expert_offsets, gates,
+                                   grouped_in, grouped_out)
+    return results

--- a/tests/test_scattermoe.py
+++ b/tests/test_scattermoe.py
@@ -1,0 +1,206 @@
+import torch
+import pytest
+from scattermoe.kernels.ops import padded_block_indices
+from scattermoe_utils.parallel_linear_lora import parallel_linear_lora
+
+# ---------------------- HELPERS -----------------------
+
+# build 
+def build_expert_model_for_test(
+    num_experts: int = 2, 
+    module_tag: str = "lin",
+    input_dim: int = 128,
+    output_dim: int = 16,
+    bias: bool = False,
+):
+
+    # this is a expert model that takes in scattered inputs
+    # and ouputs grouped
+    class ExpertModel(torch.nn.Module):
+        
+        def __init__(self):
+            super().__init__()
+            
+            self.num_experts = num_experts
+            self.module_tag = module_tag
+            self.experts = torch.nn.ModuleDict({
+                f'{module_tag}_{i}': torch.nn.Linear(
+                    input_dim, output_dim, bias=bias,
+                ) for i in range(num_experts)
+            })
+                
+        def forward(
+            self, X, sorted_expert_idxs, sorted_scattered_idxs
+        ):
+            # this forward takes in scattered inputs
+            # - build the output group-by-group
+            output = []
+            for i in range(num_experts):
+
+                expert = getattr(self.experts, f'{module_tag}_{i}')
+
+                # get the inputs for current expert
+                d = X[sorted_scattered_idxs[sorted_expert_idxs == i]]
+
+                # get expert output
+                output.append(expert(d))
+
+            # concatenate outputs
+            return torch.cat(output)
+            
+        def prepare_inputs_for_generation(self):
+            pass
+
+    return ExpertModel()
+
+def build_lora_model_for_test(
+    r: int, lora_alpha: float, lora_dropout: float=0., lora_bias: str = "none",
+    **kwargs,
+):
+    from peft import get_peft_model, LoraConfig, TaskType
+
+    model = build_expert_model_for_test(**kwargs)
+
+    # build a causallm
+    peft_config = LoraConfig(
+        task_type=TaskType.CAUSAL_LM, 
+        inference_mode=False, 
+        r=r, lora_alpha=lora_alpha, lora_dropout=lora_dropout,
+        bias=lora_bias,
+        target_modules = [
+            f'{model.module_tag}_{i}' for i in 
+            range(model.num_experts)
+        ], 
+    )
+
+    return get_peft_model(model, peft_config).get_base_model()
+
+def build_inputs_for_test(
+    num_tokens: int = 10, input_dim: int = 128,
+):
+    # for now:
+    assert num_tokens == 10, "only implemented for 10 tokens now"
+    X = torch.randn((num_tokens, input_dim))
+    sorted_expert_idxs = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1, 1, 1])
+    sorted_scattered_idxs = torch.tensor([4, 6, 8, 9, 0, 1, 2, 3, 5, 7])
+
+    return X, sorted_expert_idxs, sorted_scattered_idxs
+
+def get_params_for_parallel_forward_lora(
+    model: torch.nn.Module, 
+):
+    W, A, B = [], [], []
+
+    tag = model.module_tag
+    for i in range(model.num_experts):
+        expert = getattr(model.experts, f'{tag}_{i}')
+        W.append(expert.base_layer.weight.T.unsqueeze(0))
+        A.append(expert.lora_A.default.weight.T.unsqueeze(0))
+        B.append(expert.lora_B.default.weight.T.unsqueeze(0))
+
+    W = torch.concat(W)
+    A = torch.concat(A)
+    B = torch.concat(B)
+    A.retain_grad()
+    B.retain_grad()
+    return (W, A, B)
+
+# ---------------------- TESTS -----------------------
+
+# NOTE: currently now cannot handle
+# - lora dropout
+# - lora bias
+# - lora_r < 16
+MODEL_LORA = {
+    'small-lora-no-dropout': {
+        "r": 16, "lora_alpha": 32, "lora_dropout": 0., "lora_bias": "none",
+        "input_dim": 128, "output_dim": 16, "bias": False,
+        "num_experts": 2,
+    }
+}
+
+@pytest.fixture()
+def models(seed: int = 42):
+    torch.manual_seed(seed)
+
+    yield {
+        tag : (
+            build_lora_model_for_test(**kwargs).to('cuda'), 
+            kwargs
+        )
+        for tag, kwargs in MODEL_LORA.items()
+    }
+
+@pytest.fixture()
+def inputs(seed: int = 42):
+    INPUTS = [(10, 128)]
+
+    torch.manual_seed(seed)
+
+    _inputs = {}
+    for num_tokens, input_dim in INPUTS:
+        X, sei, ssi = build_inputs_for_test(num_tokens, input_dim)
+        _inputs[(num_tokens, input_dim)] = (
+            X.to('cuda'), sei.to('cuda'), ssi.to('cuda')
+        )
+
+    yield _inputs
+
+@pytest.mark.parametrize(
+    "model_tag,num_tokens", [('small-lora-no-dropout', 10)]
+)
+def test_scattermoe_with_lora_adapters(
+    model_tag, num_tokens, models, inputs
+):
+
+    model, model_kwargs = models[model_tag]
+    X, sorted_expert_idxs, sorted_scattered_idxs = inputs[
+        (num_tokens, model_kwargs["input_dim"])
+    ]
+
+    padded_block_idxs, expert_offsets = padded_block_indices(
+        sorted_expert_idxs, model_kwargs['num_experts']
+    )
+
+    for p in model.parameters():
+        if p.grad is not None:
+            p.grad = None
+
+    out = model(X, sorted_expert_idxs, sorted_scattered_idxs)
+    loss = out.norm()
+    loss.backward()
+
+    if 'lora' in model_tag:
+
+        tag = model.module_tag
+        refs = []
+        for i in range(model.num_experts):
+            expert = getattr(model.experts, f'{tag}_{i}')
+            refs.append(
+                expert.lora_B.default.weight.grad.T.detach().cpu().clone()
+            )
+
+        W, A, B = get_params_for_parallel_forward_lora(model)
+        A.grad = None
+        B.grad = None
+
+        out2 = parallel_linear_lora(
+            X, W, A, B, 
+            model_kwargs['r'], model_kwargs['lora_alpha'], 1,
+            sorted_expert_idxs, sorted_scattered_idxs,
+            padded_block_idxs, expert_offsets,
+            grouped_in=False, grouped_out=True
+        )
+        loss2 = out2.norm()
+        loss2.backward()
+        assert torch.allclose(out, out2, atol=1e-2), \
+            "outputs differ"
+
+        tag = model.module_tag
+        for i in range(model.num_experts):
+            expert = getattr(model.experts, f'{tag}_{i}')
+            assert torch.allclose(refs[i], B.grad[i].detach().cpu(), atol=1e-2), \
+                f"B gradients differ at expert {i}"
+    else:
+        raise NotImplementedError
+

--- a/train_accelerate_fsdp2.py
+++ b/train_accelerate_fsdp2.py
@@ -241,7 +241,8 @@ def main(
             use_lora in {"all", "mlp-only"} # if need adapters
         ):
             # add these extra here 
-            tm += ["up_proj", "down_proj", "gate_proj"]
+            tm += ["w1", "w2", "w3"]
+
 
         peft_config = LoraConfig(
             task_type=TaskType.CAUSAL_LM,

--- a/train_accelerate_fsdp2.py
+++ b/train_accelerate_fsdp2.py
@@ -242,12 +242,13 @@ def main(
             assert use_scattermoe, "lora adapters cannot be used on MLP without scattermoe"
 
             from megablocks.layers.dmoe import ParallelDroplessMLP
-            from megablocks_utils.peft_utils import ParallelDroplessMLP as LoRAParallelDroplessMLP
+            from megablocks_utils.peft_utils import ParallelDroplessMLP as LoRAParallelDroplessMLP, ARTIFACTS
+
+            # inject this so we can replicate
+            ARTIFACTS['device_mesh'] = device_mesh
 
             # inject a custom module for MLP since SparseMLP is not 
             # a supported class
-            # - FIXME: does not take care of sharding the lora adapters
-            #   so the training results is incorrect now
             peft_config._register_custom_module({
                 ParallelDroplessMLP: LoRAParallelDroplessMLP
             })
@@ -269,7 +270,6 @@ def main(
             # - lora has no bias
            for name, p in model.named_parameters():
                if "experts" in name and 'lora_' in name:
-                   # p.data = p.data.to(torch.float32)
                    p.requires_grad = True
 
     # prepare the model without accelerate

--- a/train_accelerate_fsdp2.py
+++ b/train_accelerate_fsdp2.py
@@ -274,6 +274,7 @@ def main(
             from megablocks.layers.moe import ParallelMLP
             from megablocks.layers.dmoe import ParallelDroplessMLP
             from megablocks_utils.peft_utils import ParallelDroplessMLP as LoRAParallelDroplessMLP, ARTIFACTS
+            from megablocks_utils.peft_utils import ParallelMLP as LoRADroplessMLP
 
             # inject this so we can replicate
             ARTIFACTS['device_mesh'] = device_mesh
@@ -282,7 +283,7 @@ def main(
             # a supported class
             peft_config._register_custom_module({
                 ParallelDroplessMLP: LoRAParallelDroplessMLP,
-                ParallelMLP: LoRAParallelDroplessMLP,
+                ParallelMLP: LoRADroplessMLP,
             })
             
             peft_config.target_modules.add("experts")
@@ -367,6 +368,11 @@ def main(
                 dataloader.set_epoch(epoch)
 
             for batch in dataloader:
+
+                # if torch.distributed.get_rank() == 0:
+                #     torch.save(batch, 'batch')
+                # torch.distributed.breakpoint()
+                batch = torch.load('batch.pt')
 
                 step += 1
 

--- a/train_accelerate_fsdp2.py
+++ b/train_accelerate_fsdp2.py
@@ -52,6 +52,7 @@ def main(
     per_device_train_batch_size: int = 1,
     gradient_accumulation_steps: int = 1,
     use_megablocks_sharding: bool = False,
+    use_scattermoe: bool = False,
     lr_scheduler_type: str = 'linear',
     num_epochs: int = 1,
     num_warmup_steps: int = 0,
@@ -129,6 +130,10 @@ def main(
                 has_bias=False,
                 fp16=(load_model_dtype == 'float16'),
                 bf16=(load_model_dtype == 'bfloat16'),
+                mlp_impl=(
+                    "sparse" if not use_scattermoe else
+                    "scattermoe"
+                )
             ),
         )
 


### PR DESCRIPTION
### Prologue

**Background**: 
- Expert parallel refers to splitting experts into smaller groups and putting each group in different machines. Each machine processes the expert's tokens in parallel. 
- Parallelisation of experts *within a machine* is achieved by writing custom GPU kernels that perform multi-threaded computation.
   - megablocks uses kernels for originally written for sparse matrix operations. However this strategy first requires grouping to put all tokens for an expert contiguously. This operation requires mem copy which is bottlenecked by I/O speeds.
   - [scattermoe](https://github.com/shawntan/scattermoe) avoids I/O bottlenecks by fusing the group operation with the compute, achieving excessive copies by using pointer arithmetic to perform grouping.

**Goals**: 
1. provide capability for switching sparse matrix kernels with scattermoe kernels. 
2. Extend scattermoe kernels to also handle lora adapters; megablocks sparse matrix kernels cannot handle lora adapters.


<!--
**Idea**: Currently megablocks uses `SparseMLP` matrix operations to handle **dropless** MoE operations. On the other hand, [scattermoe](https://github.com/shawntan/scattermoe) improves by fusing grouping operations reducing copies. Want to provide `scattermoe` as an alternative to sparse multiplies.
-->

This PR:
- Provides `scattermoe` functionality in `train_acceleration_fsdp2.py` script.
- **new_flag** `use_scattermoe`: If `use_scattermoe=True`, then `scattermoe`  will be dropped-in to replace sparse matrix kernels used for the experts. 
- Provides modified `scattermoe` kernels that also handle lora adapters (one set of adapters per expert) in a single *fused operation*.
- **updated flag**`use_lora`: now supports all these modes `none, all, attn-only, mlp-only`.
   * NOTE: if `use_scattermoe=True` (see above), then `use_lora="all"` or `"mlp-only"` is **not supported**, as megablocks does not support lora adapters.
   
Known Issues:
- current `scattermoe_lora` implementation does not support lora bias, no dropout, and only supports `r >= 16`. (dropout could be handled similar to this https://github.com/foundation-model-stack/fms-acceleration/pull/37)

### Performance Results

Note:
- tested on `mistralai/Mixtral-8x7B-Instruct-v0.1`
- megablocks + scattermoe = **scatterblocks**
- `ep_size`: refers to the number of machines that the experts are sharded over.

**Full Finetuning**
ep_size | Emb, Attn | MoE | train_runtime (s) | Speedup | gpu_mem_used_peak (MiB) | gpu_mem_alloc (MiB)
--|--|--|--|--|--|--
 no parallel | FSDP2 | FSDP2 | 3037 | - | 59 | 47
8 | FSDP2 | megablocks | 871 | 3.5x | **49** | **47**
8 | FSDP2 | **scatterblocks** | 819  | **3.7x** | **49** | **47**
4 | FSDP2 | megablocks | OOM  | - | OOM | OOM
4 | FSDP2 | **scatterblocks** | OOM  | - | OOM | OOM

**LoRA (r=16, use_lora=attn)**
 ep_size | Emb, Attn | MoE | train_runtime (s) | Speedup | gpu_mem_used_peak (MiB) | gpu_mem_alloc (MiB)
--|--|--|--|--|--|--
 no parallel | FSDP2 | FSDP2 | 2137 | - | 22 | 12
 8 | FSDP2 | megablocks | 878 | 2.5x | 14 | 12
 4 | FSDP2 | megablocks | 878 | 2.5x | 26 | 25
 4 | FSDP2 | **scatterblocks** | **831** |  **2.6x** | **25** | **24**

**LoRA (r=16, use_lora=all)**
 ep_size | Emb, Attn | MoE | train_runtime (s) | Speedup | gpu_mem_used_peak (MiB) | gpu_mem_alloc (MiB)
--|--|--|--|--|--|--
no parallel | FSDP2 | FSDP | 2844 | - | 22 | 12
4 | FSDP2 | **scatterblocks** | 1048 | 2.7x | 26 | 25
4 | FSDP2 | scatter-tp | 4188 |  | 26 | 25

### Design Discussion

Refer to the below picture below depicting Expert Parallel 
- there are two levels i) across machines, and ii) within a machine. 

**Across Machines**
- routers are replicated and experts spread out across machines
- local gather and scatters used to group / scatter tokens belonging to a particular expert
- `all-to-all` used to send tokens across machines to where they reside

**Within Machine**
- a local sort used to compute indices that group the expert tokens that land in that machine.
- `permute-and-compute` primitive used to process multiple experts *in parallel* within a single machine.
![image](https://github.com/user-attachments/assets/c357ae1a-b2b8-45b2-8e26-ebb433c571a9)


**Difference between SparseMLP and ScatterMoE**

See the picture below: 
- SparseMLP will require additional local gather to position the inputs in grouped order and then the sparse matrix multiply is executed. 
- ScatterMoE will use pointer arithmetic to process a particular experts tokens *without the explicit gather*. The savings come from minimizing the amount of memory copies.

![image](https://github.com/user-attachments/assets/d6e32bc9-579b-47e4-817a-b4869c15383e)

