### PR TITLE
Add 2D ScatterMoE with Tensor Parallel

### DIFF
--- a/megablocks_utils/config_utils.py
+++ b/megablocks_utils/config_utils.py
@@ -7,6 +7,7 @@ from megablocks.layers.dmlp_registry import _REGISTRY
 # from megablocks.layers import mlp
 from .sparse_mlp2 import SparseMLPv2
 from .peft_utils import ParallelDroplessMLP as LoRAParallelDroplessMLP
+import megablocks.ops as ops
 from megablocks.layers.moe import ParallelMLP
 from megablocks.layers.dmoe import ParallelDroplessMLP
 from megablocks.layers.mlp import resolve_dtensor
@@ -114,7 +115,7 @@ def update_mlp_registry():
         hidden_states = scattered_experts(
             x,
             *get_weights(self, "w1"),
-            1,
+            1 if self.args.moe_expert_model_parallelism else top_k,
             bin_ids, # sorted_expert_idxs,
             indices, # sorted_scattered_idxs,
             padded_block_idxs,
@@ -126,7 +127,7 @@ def update_mlp_registry():
         hidden_states2 = scattered_experts(
             x,
             *get_weights(self, "w3"),
-            1,
+            1 if self.args.moe_expert_model_parallelism else top_k,
             bin_ids, # sorted_expert_idxs,
             indices, # sorted_scattered_idxs,
             padded_block_idxs,
@@ -160,7 +161,6 @@ def update_mlp_registry():
         expert_capactiy,
         top_k,
     ):
-
         if self.args.mlp_impl == 'sparse':
             _func = self.sparse_permute_and_compute
         elif self.args.mlp_impl == 'scattermoe':
@@ -184,6 +184,39 @@ def update_mlp_registry():
     _REGISTRY['mlp']['scattermoe'] = SparseMLPv2
     
     ParallelDroplessMLP.permute_and_compute = permute_and_compute
+
+    # this is the permute and compute for the ParallelMLP version
+    # - we need to overide it with the above permute and compute
+    # - the "dmoe" version of parallel and compute has the 
+    #   binned gather and scatter done outside
+    # - this needs to reduce the expert weights
+    def permute_and_compute_parallel_mlp(
+        self,
+        x,
+        tokens_per_expert,  # unused
+        indices,
+        bin_ids,  # unused
+        expert_weights,
+        bins,
+        expert_capacity,
+        top_k,
+    ):
+        # need to handle the weights
+        # this is done in the MoE.permute_and_compute
+        if len(x.shape) == 3:
+            x = x.view(-1, x.shape[-1])
+
+        x = permute_and_compute(
+            self, x, tokens_per_expert, indices,
+            bin_ids, expert_weights, bins, expert_capacity, top_k
+        )
+        # following
+        # https://github.com/IBM/dolomite-engine/blob/b3ad5703ae32060f07339b664d3caca3e2c5e70a/dolomite_engine/hf_models/models/moe_dolomite/moe/base.py
+
+        return ops.scatter(x, indices, bin_ids, expert_weights, bins, top_k)
+
+    ParallelMLP.permute_and_compute = permute_and_compute_parallel_mlp
+    # ParallelMLP.permute_and_compute = permute_and_compute
 
     def forward_router(self, x):
         if self.training and self.args.moe_jitter_eps is not None:

--- a/megablocks_utils/peft_utils.py
+++ b/megablocks_utils/peft_utils.py
@@ -41,12 +41,15 @@ class ParallelDroplessMLP(torch.nn.Module, LoraLayer):
         self._active_adapter = adapter_name
 
         device_mesh = ARTIFACTS.get('device_mesh')
+        ep_degree = 1
         if device_mesh is not None:
             # for A and B, of size ff_dim x hidd
-            placements = (
-                [Shard(0)] + 
-                [Replicate() for _ in range(device_mesh.ndim-1)]
-            )
+            # placements = (
+            #     [Shard(0)] + 
+            #     [Replicate() for _ in range(device_mesh.ndim-1)]
+            # )
+            _, ep_degree = device_mesh.shape
+            placements = [Replicate(), Shard(0)]
 
         base_layer._lora_pointers = {}
 
@@ -89,7 +92,8 @@ class ParallelDroplessMLP(torch.nn.Module, LoraLayer):
                     A, 'weight', 
                     torch.nn.Parameter(
                         distribute_tensor(
-                            weight.repeat(num_experts, 1), 
+                            # weight.repeat(num_experts, 1), 
+                            weight.repeat(ep_degree, 1), 
                             device_mesh,
                             placements
                         ),
@@ -113,7 +117,8 @@ class ParallelDroplessMLP(torch.nn.Module, LoraLayer):
                     B, 'weight', 
                     torch.nn.Parameter(
                         distribute_tensor(
-                            weight.repeat(num_experts, 1), 
+                            # weight.repeat(num_experts, 1), 
+                            weight.repeat(ep_degree, 1), 
                             device_mesh,
                             placements
                         ),
@@ -130,6 +135,148 @@ class ParallelDroplessMLP(torch.nn.Module, LoraLayer):
             ] = (
                 A.weight, B.weight, r, alpha,
                 base_layer.hidden_size, base_layer.ffn_hidden_size,
+            )
+    
+    def __getattr__(self, name: str) -> Any:
+        """Forward missing attributes to the wrapped module."""
+        try:
+            return super().__getattr__(name)  # defer to nn.Module's logic
+        except AttributeError:
+            return getattr(self.base_layer, name)
+
+    def forward(self, *args, **kwargs):
+        return self.base_layer(*args, **kwargs)
+
+class ParallelMLP(torch.nn.Module, LoraLayer):
+
+    # Lora implemented in a dense layer
+    def __init__(
+        self,
+        base_layer,
+        adapter_name: str,
+        # mb_args: Arguments,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.0,
+        init_lora_weights: Union[bool, str] = True,
+        **kwargs,
+    ) -> None:
+        # super().__init__(mb_args)
+        super().__init__()
+        LoraLayer.__init__(self, base_layer, **kwargs)
+        # - base_layer will be ParallelMLP
+        #  
+        num_experts = mpu.experts_per_rank(self.args)
+
+        # dummy not really used
+        self._active_adapter = adapter_name
+
+        device_mesh = ARTIFACTS.get('device_mesh')
+        ep_degree = 1
+        if device_mesh is not None:
+            # for A and B, of size ff_dim x hidd
+            placements = {
+                "A": [Replicate(), Replicate()],
+                "B": [Replicate(), Shard(0)],
+            } 
+            _, ep_degree = device_mesh.shape
+            # placements = (
+            #     [Shard(0)] + 
+            #     [Replicate() for _ in range(device_mesh.ndim-1)]
+            # )
+            # placements = [Replicate(), Shard(0)]
+
+        # we need to it cover the base layer
+        # - this will have A to be size (k, hd)
+        # - this will have B to be size (ffn, k)
+        self.in_features = base_layer.hidden_size * num_experts
+        # self.out_features = base_layer.ffn_hidden_size * num_experts // ep_degree
+        self.out_features = base_layer.ffn_hidden_size * num_experts
+
+        base_layer._lora_pointers = {}
+
+        # assume that all the parameters of ParallelMLP.mlp 
+        # are weights
+        # - should be single layer
+        for name, _ in base_layer.mlp.named_parameters():
+            self.update_layer(
+                name,
+                r,
+                lora_alpha=lora_alpha,
+                lora_dropout=lora_dropout,
+                init_lora_weights=init_lora_weights,
+                use_rslora=False,
+                use_dora=False,
+            )
+
+            # need to adjust the A
+            # - ()
+            A = getattr(self.lora_A, name)
+            if device_mesh is None:
+                A.weight.data = A.weight.data.T # HACK
+            else:
+                weight = A.weight.data.T
+
+                # must cast here otherwise, the casting on the 
+                # Dtensor will not affect the local
+                if self.args.bf16 or self.args.fp16:
+                    weight = weight.to(
+                        torch.bfloat16 if self.args.bf16
+                        else torch.float16
+                    )
+
+                # - NOTE: if we do it this way, all reps
+                # will begin with the same initialization of A
+                # - it is ok for random, but not ok for other
+                # - types of intialization
+                delattr(A, 'weight')
+                setattr(
+                    A, 'weight', 
+                    torch.nn.Parameter(
+                        distribute_tensor(
+                            # weight.repeat(ep_degree, 1), 
+                            weight,
+                            device_mesh,
+                            placements["A"]
+                        ),
+                        requires_grad=True
+                    )
+                )
+
+            B = getattr(self.lora_B, name)
+            if device_mesh is not None:
+                weight = B.weight.data
+
+                # cast (see above)
+                if self.args.bf16 or self.args.fp16:
+                    weight = weight.to(
+                        torch.bfloat16 if self.args.bf16
+                        else torch.float16
+                    )
+
+                delattr(B, 'weight')
+                setattr(
+                    B, 'weight', 
+                    torch.nn.Parameter(
+                        distribute_tensor(
+                            weight.repeat(ep_degree, 1), 
+                            device_mesh,
+                            placements["B"]
+                        ),
+                        requires_grad=True
+                    )
+                )
+
+            r = self.r[name]
+            alpha = self.lora_alpha[name]
+
+            # put pointers in the base layer 
+            base_layer._lora_pointers[
+                name
+            ] = (
+                A.weight, B.weight, r, alpha,
+                # base_layer.hidden_size, base_layer.ffn_hidden_size // ep_degree,
+                base_layer.hidden_size, base_layer.ffn_hidden_size
             )
     
     def __getattr__(self, name: str) -> Any:

--- a/megablocks_utils/tpmoe.py
+++ b/megablocks_utils/tpmoe.py
@@ -1,0 +1,32 @@
+from  megablocks.layers.moe import MoE, ParallelMLP
+from megablocks.layers import common, dmlp_registry, moe, mpu
+from megablocks.layers.arguments import Arguments
+
+class TpMLP(moe.ParallelMLP):
+    def __init__(self, args: Arguments):
+        super().__init__(args)
+        self.hidden_size = args.hidden_size
+        self.ffn_hidden_size = mpu.features_per_rank(args)
+
+        # REMOVE THIS?
+        assert args.mlp_impl == 'scattermoe', \
+            "only scattermoe version of TP available"
+
+    # this will implement a sharded TP MLP
+    def forward_once(self, x, expert_weights, top_experts):
+        pass
+
+
+# tensor parallel version
+class TpMoE(MoE):
+    
+    # - MoE._init_experts_mlp initializes experts to 
+    #  the correct type of MLP
+    # 
+    # MoE.router(x) is called and returns
+    # - scores, expert_weights, expert_indices
+    # - these are passed to MoE.experts
+    # ParallelMLP.forward will call ParallelMLP.forward_once
+
+    def _init_experts_mlp(self, args: Arguments):
+        return TpMLP(args)

--- a/train_accelerate_fsdp2.py
+++ b/train_accelerate_fsdp2.py
@@ -274,6 +274,7 @@ def main(
             from megablocks.layers.moe import ParallelMLP
             from megablocks.layers.dmoe import ParallelDroplessMLP
             from megablocks_utils.peft_utils import ParallelDroplessMLP as LoRAParallelDroplessMLP, ARTIFACTS
+            from megablocks_utils.peft_utils import ParallelMLP as LoRADroplessMLP
 
             # inject this so we can replicate
             ARTIFACTS['device_mesh'] = device_mesh
@@ -282,7 +283,7 @@ def main(
             # a supported class
             peft_config._register_custom_module({
                 ParallelDroplessMLP: LoRAParallelDroplessMLP,
-                ParallelMLP: LoRAParallelDroplessMLP,
+                ParallelMLP: LoRADroplessMLP,
             })
             
             peft_config.target_modules.add("experts")
@@ -367,6 +368,11 @@ def main(
                 dataloader.set_epoch(epoch)
 
             for batch in dataloader:
+
+                # if torch.distributed.get_rank() == 0:
+                #     torch.save(batch, 'batch')
+                # torch.distributed.breakpoint()
+                batch = torch.load('batch.pt')
 
                 step += 1
 


### PR DESCRIPTION
This is an adaptation of the TP implementation in https://github.com/IBM/dolomite-engine/tree/main/dolomite_engine/hf_models/models/moe_dolomite_TP
- here we utilize the `megablocks.ops.scatter` to reduce the `top-k` tokens across `expert_weights` to make it slightly more efficient.
- tested on the lora for Mixtral 8x7b (fullFT will be OOM for this model size). Save full FT tests for later when we try on smaller models

Tensor Parallel will cut on the MoE'` feed-forward dimension, and perform one all-reduce on the output of the experts. This is as shown in the below diagram

![image](https://github.com/user-attachments/assets/b29b2278-2237-4087-870a-1c56e2376e70)
- we can see that the amount of parameters that go into a single device will be the same regardless for *expert parallel* and *tensor parallel*. 
- However the *data parallel* dimension is compromised, because TP does not perform the `all-to-all`, this means that the data has to be replicated in the TP dimension

### Performance

**LoRA (r=16, use_lora=all)**
 ep_size | Emb, Attn | MoE | train_runtime (s) | Speedup | gpu_mem_used_peak (MiB) | gpu_mem_alloc (MiB)
--|--|--|--|--|--|--
no parallel | FSDP2 | FSDP | 2844 | - | 22 | 12
4 | FSDP2 | **scatterblocks** | 1048 | 2.7x | 26 | 25
4 | FSDP2 | scatter-tp | 4188 |  | 26 | 25

As you can see, the TP version is even slower than the LoRA baseline
- turns out the drawback of running `ep_degree` times more steps, outweighs the cost of FSDP's gather + reduce
- one might argue that in the extreme inbalance case, then EP will run `ep_degree` slower, but this is equivalent to TP's `ep_degree` times more steps.

The loss curve is shown below:
- note there is some problem with the `grad_norm` that is measured in our script (due to accelerate).
- it is off by a constant factor, the plot before shows it adjusted
![image](https://github.com/user-attachments/assets/2a4078ec-14f8-4222-85f3-e49cc9e9c1c2)


So one can expect that this can be quite disadvantageous for TP as compared to EP
- it has to manage the same number of parameters. There are *no savings* in the scatter kernels.
- and it has to run more steps.
- for EP, the *all-to-all* only needs to be done within a replication. 
- for both EP and TP across replicates need to reduce

<img width="832" alt="image" src="https://github.com/user-attachments/assets/132e4d68-7f73-498b-8f19-f9761a8bcb62">





